### PR TITLE
Don't show the 'No such file or directory' error when first running update.py

### DIFF
--- a/cookiecutter-pymorphy2-dicts/hooks/post_gen_project.sh
+++ b/cookiecutter-pymorphy2-dicts/hooks/post_gen_project.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 PACKAGE_DATA="{{ cookiecutter.package_name }}/data"
 
-rm -r $PACKAGE_DATA
+rm -rf $PACKAGE_DATA
 cp -r ../compiled-dicts $PACKAGE_DATA


### PR DESCRIPTION
Added the `-f` flag to `rm` to conceal the trailing error message. Without it, the first run of the update.py script ends with the following:

```
Done.

Creating Python package
rm: pymorphy2_dicts_ru/data: No such file or directory
```